### PR TITLE
Updated default box to debian/buster64

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "debian/stretch64"
+  config.vm.box = "debian/buster64"
   config.ssh.insert_key = false
 
   config.vm.provider :virtualbox do |v|


### PR DESCRIPTION
Fixes #7.

The default python version used in debian9 is python 3.5, which is not supported anymore by the latest versions of django.