### PR TITLE
Increase vagrant memory to 2GB and video memory to 16MB

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,8 +9,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provider :virtualbox do |v|
     v.name = "openwisp2"
-    v.memory = 512
     v.cpus = 2
+    v.memory = 2048
+    v.customize ["modifyvm", :id, "--vram", "16"]
   end
 
   config.vm.hostname = "openwisp2"


### PR DESCRIPTION
Running into issues when installing the dependencies (usually last steps on ansible role).
The steps just fail and i found out this to be lack of memory (OpenWISP does mention 1GB minimum requirement).

In addition, 8MB is bellow the recommended minimum VRAM for Vbox VMs, which is 16MB.

Finally, after i got it working and reinstalled a few times to test right, it just seems to be severely lacking memory and is painfully slow.

```
touch ~/.ssh/config
vagrant ssh-config >> ~/.ssh/config
vagrant ssh

sudo apt install -y htop
htop
```
![image](https://user-images.githubusercontent.com/903711/168483697-a6d2b814-c852-4c14-867d-811efbca2835.png)
So always around 980-990MB of usage even when idle.

Which brings us to raising this setting to 2GB so there's sufficient available RAM for normal usage and we don't swap any more, so we get good performance.